### PR TITLE
[FIX] Use setPoint in the website charts to show both brew and steam temperatures

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1652,7 +1652,7 @@ void looppid() {
 
     if ((millis() - lastTempEvent) > tempEventInterval) {
         //send temperatures to website endpoint
-        sendTempEvent(temperature, brewSetPoint, pidOutput);
+        sendTempEvent(temperature, setPoint, pidOutput);
         lastTempEvent = millis();
 
         #if VERBOSE


### PR DESCRIPTION
**BEFORE:**
Setpoint in the chart was always the brewSetpoint leading to incorrect data when Steam Mode was used.

**AFTER:**
Setpoint uses the global setPoint which is set depending on the steam mode status.

<img width="746" alt="Screenshot 2023-01-15 at 8 29 03 PM" src="https://user-images.githubusercontent.com/210643/212562816-04b7920f-90d2-491b-9af5-2b03bf816d18.png">
